### PR TITLE
This commit fixed Client spoof to be injectable directly to the minecraft library, also adds new types of client spoofs

### DIFF
--- a/src/main/java/keystrokesmod/mixins/impl/network/MixinClientSpoofer.java
+++ b/src/main/java/keystrokesmod/mixins/impl/network/MixinClientSpoofer.java
@@ -1,0 +1,57 @@
+package keystrokesmod.mixins.impl.network;
+
+import io.netty.buffer.Unpooled;
+import keystrokesmod.module.impl.other.ClientSpoofer;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.PlayerControllerMP;
+import net.minecraft.client.multiplayer.WorldClient;
+import net.minecraft.client.network.NetHandlerPlayClient;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.network.PacketThreadUtil;
+import net.minecraft.network.play.client.C17PacketCustomPayload;
+import net.minecraft.network.play.server.S01PacketJoinGame;
+import net.minecraft.world.WorldSettings;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(NetHandlerPlayClient.class)
+public abstract class MixinClientSpoofer {
+    @Shadow
+    @Final
+    private NetworkManager netManager;
+
+    @Shadow
+    private Minecraft gameController;
+    @Shadow
+    private WorldClient clientWorldController;
+
+    @Shadow
+    public int currentServerMaxPlayers;
+
+
+    @Inject(method = "handleJoinGame", at = @At("HEAD"), cancellable = true)
+    private void handleJoinGame(S01PacketJoinGame packetIn, final CallbackInfo callbackInfo) {
+        if (Minecraft.getMinecraft().isIntegratedServerRunning())
+            return;
+
+        PacketThreadUtil.checkThreadAndEnqueue(packetIn, (NetHandlerPlayClient) (Object) this, this.gameController);
+        this.gameController.playerController = new PlayerControllerMP(this.gameController, (NetHandlerPlayClient) (Object) this);
+        this.clientWorldController = new WorldClient((NetHandlerPlayClient) (Object) this, new WorldSettings(0L, packetIn.getGameType(), false, packetIn.isHardcoreMode(), packetIn.getWorldType()), packetIn.getDimension(), packetIn.getDifficulty(), this.gameController.mcProfiler);
+        this.gameController.gameSettings.difficulty = packetIn.getDifficulty();
+        this.gameController.loadWorld(this.clientWorldController);
+        this.gameController.thePlayer.dimension = packetIn.getDimension();
+        this.gameController.displayGuiScreen(null);
+        this.gameController.thePlayer.setEntityId(packetIn.getEntityId());
+        this.currentServerMaxPlayers = packetIn.getMaxPlayers();
+        this.gameController.thePlayer.setReducedDebug(packetIn.isReducedDebugInfo());
+        this.gameController.playerController.setGameType(packetIn.getGameType());
+        this.gameController.gameSettings.sendSettingsToServer();
+        this.netManager.sendPacket(new C17PacketCustomPayload(ClientSpoofer.getBrandName().channel, (new PacketBuffer(Unpooled.buffer())).writeString(ClientSpoofer.getBrandName().brand)));
+        callbackInfo.cancel();
+    }
+}

--- a/src/main/java/keystrokesmod/module/impl/other/ClientSpoofer.java
+++ b/src/main/java/keystrokesmod/module/impl/other/ClientSpoofer.java
@@ -1,6 +1,7 @@
 package keystrokesmod.module.impl.other;
 
 import io.netty.buffer.Unpooled;
+import keystrokesmod.Raven;
 import keystrokesmod.event.SendPacketEvent;
 import keystrokesmod.mixins.impl.network.C17PacketCustomPayloadAccessor;
 import keystrokesmod.module.Module;
@@ -13,53 +14,73 @@ import net.minecraftforge.fml.common.network.internal.FMLProxyPacket;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
+
+
 public class ClientSpoofer extends Module {
     private final ModeSetting mode = new ModeSetting("Mode", SpoofMode.getNames(), 0);
     public final ButtonSetting cancelForgePacket = new ButtonSetting("Cancel Forge packet", false);
+    private static SpoofMode currentSpoof = SpoofMode.FORGE;
 
     public ClientSpoofer() {
         super("ClientSpoofer", category.other);
         this.registerSetting(mode, cancelForgePacket);
     }
 
+    @Override
+    public void onUpdate() {
+        currentSpoof = SpoofMode.values()[(int) mode.getInput()];
+        if(currentSpoof == SpoofMode.FORGE) {
+            cancelForgePacket.disable();
+        } else {
+            Raven.getModuleManager().getModule("ModSpoofer").enable();
+            cancelForgePacket.disable();
+        }
+    }
+
     @SubscribeEvent
     public void onSendPacket(@NotNull SendPacketEvent event) {
-        if (event.getPacket() instanceof C17PacketCustomPayload) {
-            C17PacketCustomPayload packet = (C17PacketCustomPayload) event.getPacket();
-
-
-            String brand = SpoofMode.values()[(int) mode.getInput()].brand;
-            if (brand == null)
-                event.setCanceled(true);
-            else
-                ((C17PacketCustomPayloadAccessor) packet).setData(createPacketBuffer(brand));
-        } else if (event.getPacket() instanceof FMLProxyPacket && cancelForgePacket.isToggled()) {
+        if (event.getPacket() instanceof FMLProxyPacket && cancelForgePacket.isToggled()) {
             event.setCanceled(true);
         }
     }
 
+
+    public static BrandInfo getBrandName() {
+        return new BrandInfo(currentSpoof.brand, currentSpoof.channel);
+    }
+
+
+    public static class BrandInfo {
+        public final String brand;
+        public final String channel;
+
+        public BrandInfo(String brand, String channel) {
+            this.brand = brand;
+            this.channel = channel;
+        }
+    }
+
     enum SpoofMode {
-        VANILLA("Vanilla", "vanilla"),
-        LUNAR("Lunar", "lunarclient:v2.12.3-2351"),
-        CHEATBREAKER("Cheatbreaker", "CB"),
-        CANCEL("Cancel", null);
+        FORGE("Forge", "FML", "MC|Brand"),
+        VANILLA("Vanilla", "vanilla", "MC|Brand"),
+        LUNAR("Lunar", "lunarclient:v2.16.0-2426", "MC|Brand"),
+        CHEATBREAKER("Cheatbreaker", "CB", "MC|Brand"),
+        GEYSER("Geyser", "Geyser", "MC|Brand"),
+        LABYMOD("LabyMod", "LMC", "MC|Brand"),;
 
         public final String name;
         public final String brand;
+        public final String channel;
 
-        SpoofMode(String name, String brand) {
+        SpoofMode(String name, String brand, String channel) {
             this.name = name;
             this.brand = brand;
+            this.channel = channel;
         }
 
         public static String @NotNull [] getNames() {
-            final String[] result = new String[values().length];
-
-            for (int i = 0; i < values().length; i++) {
-                result[i] = values()[i].name;
-            }
-
-            return result;
+            return java.util.Arrays.stream(values()).map(spoofMode -> spoofMode.name).toArray(String[]::new);
         }
     }
 

--- a/src/main/resources/mixins.raven.json
+++ b/src/main/resources/mixins.raven.json
@@ -1,5 +1,6 @@
 {
   "required": true,
+  "minVersion": "0.7.11",
   "package": "keystrokesmod.mixins.impl",
   "refmap": "mixins.raven.refmap.json",
   "compatibilityLevel": "JAVA_8",
@@ -33,6 +34,11 @@
     "render.MixinGuiConnecting",
     "render.MixinGuiContainer",
     "render.MixinGuiScreen",
-    "render.MixinItemRenderer"
-  ]
+    "render.MixinItemRenderer",
+    "network.MixinClientSpoofer"
+  ],
+  "server": [],
+  "injectors": {
+    "defaultRequire": 1
+  }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced client spoofing functionality with new modes (GEYSER, LABYMOD) and customized player settings.
  - Added support for modifying game behavior on server join.
  
- **Enhancements**
  - Updated spoof mode handling for improved flexibility and user experience.
  
- **Compatibility**
  - Added support for Mixins version 0.7.11 to ensure compatibility with new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->