### PR TITLE
Fixed people not able to join Hypixel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 .vscode
 # BlueJ files
 *.ctxt
-.bin
+bin
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 

--- a/src/main/java/keystrokesmod/module/impl/other/ClientSpoofer.java
+++ b/src/main/java/keystrokesmod/module/impl/other/ClientSpoofer.java
@@ -3,18 +3,14 @@ package keystrokesmod.module.impl.other;
 import io.netty.buffer.Unpooled;
 import keystrokesmod.Raven;
 import keystrokesmod.event.SendPacketEvent;
-import keystrokesmod.mixins.impl.network.C17PacketCustomPayloadAccessor;
 import keystrokesmod.module.Module;
 import keystrokesmod.module.setting.impl.ButtonSetting;
 import keystrokesmod.module.setting.impl.ModeSetting;
 import net.minecraft.network.PacketBuffer;
-import net.minecraft.network.play.client.C17PacketCustomPayload;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.network.internal.FMLProxyPacket;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.Objects;
 
 
 public class ClientSpoofer extends Module {
@@ -26,7 +22,9 @@ public class ClientSpoofer extends Module {
         super("ClientSpoofer", category.other);
         this.registerSetting(mode, cancelForgePacket);
     }
-
+    public void onDisable() {
+        currentSpoof = SpoofMode.FORGE;
+    }
     @Override
     public void onUpdate() {
         currentSpoof = SpoofMode.values()[(int) mode.getInput()];
@@ -34,7 +32,6 @@ public class ClientSpoofer extends Module {
             cancelForgePacket.disable();
         } else {
             Raven.getModuleManager().getModule("ModSpoofer").enable();
-            cancelForgePacket.disable();
         }
     }
 
@@ -62,7 +59,7 @@ public class ClientSpoofer extends Module {
     }
 
     enum SpoofMode {
-        FORGE("Forge", "FML", "MC|Brand"),
+        FORGE("Forge", "FML,Forge", "MC|Brand"),
         VANILLA("Vanilla", "vanilla", "MC|Brand"),
         LUNAR("Lunar", "lunarclient:v2.16.0-2426", "MC|Brand"),
         CHEATBREAKER("Cheatbreaker", "CB", "MC|Brand"),
@@ -82,11 +79,5 @@ public class ClientSpoofer extends Module {
         public static String @NotNull [] getNames() {
             return java.util.Arrays.stream(values()).map(spoofMode -> spoofMode.name).toArray(String[]::new);
         }
-    }
-
-    @Contract("_ -> new")
-    @SuppressWarnings("All")
-    private @NotNull PacketBuffer createPacketBuffer(final @NotNull String data) {
-        return new PacketBuffer(Unpooled.buffer()).writeString(data);
     }
 }


### PR DESCRIPTION
- **Issue:** Resolves the problem that prevented users from joining Hypixel while using Spoofing as Lunar. Hypixel has access to the Lunar API and disables certain modules like FreeLook from Lunar to comply with server rules. However, since we are not on Lunar and server thinks we are on Lunar, they encounter an error on their backend, leading to disconnections.
- **Proposed Changes:** 
  - Set the default brand to be Forge to avoid conflicts with Lunar modules on Hypixel.
- **Impact:** This fix ensures that users can join Hypixel without encountering disconnections due to conflicts between the Forge brand and Lunar modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an `onDisable()` method to reset spoofing mode to Forge.

- **Bug Fixes**
  - Adjusted "Forge" spoofing mode to recognize both "FML" and "Forge".

- **Refactor**
  - Cleaned up unused imports and removed redundant method calls in the ClientSpoofer module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->