### PR TITLE
feat: Add clickgui position reset

### DIFF
--- a/src/main/java/keystrokesmod/clickgui/ClickGui.java
+++ b/src/main/java/keystrokesmod/clickgui/ClickGui.java
@@ -288,4 +288,19 @@ public class ClickGui extends GuiScreen {
         }
         return false;
     }
+    public void resetPosition() {
+        int xOffSet = 5;
+        int yOffSet = 5;
+        for(CategoryComponent category : categories.values()) {
+            category.fv(false);
+            category.x(xOffSet);
+            category.y(yOffSet);
+            xOffSet = xOffSet + 100;
+            if (xOffSet > 400) {
+                xOffSet = 5;
+                yOffSet += 120;
+            }
+        }
+
+    }
 }

--- a/src/main/java/keystrokesmod/module/impl/client/Gui.java
+++ b/src/main/java/keystrokesmod/module/impl/client/Gui.java
@@ -6,7 +6,7 @@ import keystrokesmod.module.setting.impl.ButtonSetting;
 import keystrokesmod.utility.Utils;
 
 public class Gui extends Module {
-    public static ButtonSetting removePlayerModel, translucentBackground, removeWatermark, rainBowOutlines;
+    public static ButtonSetting removePlayerModel, resetPosition, translucentBackground, removeWatermark, rainBowOutlines;
 //    public static SliderSetting font;
 
     public Gui() {
@@ -15,6 +15,7 @@ public class Gui extends Module {
         this.registerSetting(removePlayerModel = new ButtonSetting("Remove player model", false));
         this.registerSetting(removeWatermark = new ButtonSetting("Remove watermark", false));
         this.registerSetting(translucentBackground = new ButtonSetting("Translucent background", true));
+        this.registerSetting(resetPosition = new ButtonSetting("Reset position", false));
 //        this.registerSetting(font = new SliderSetting("Font", new String[]{"Minecraft", "Product Sans"}, 0));
     }
 
@@ -23,7 +24,12 @@ public class Gui extends Module {
             mc.displayGuiScreen(Raven.clickGui);
             Raven.clickGui.initMain();
         }
-
         this.disable();
+    }
+    public void guiUpdate() {
+            if (resetPosition.isToggled()) {
+                Raven.clickGui.resetPosition();
+                resetPosition.toggle();
+            }
     }
 }


### PR DESCRIPTION
Adds a new button in the GUI settings that allows users to reset the position of the clickgui categories. This enhances user experience by providing a convenient way to restore the default layout if the user accidentally moves the categories out of place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a button setting to reset the position of GUI elements.
  - Introduced a new method to update the GUI and reset positions dynamically.

- **Improvements**
  - Enhanced GUI customization by allowing users to adjust the position of categories within the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->