### PR TITLE
Update `holdingWeapon()` logic in `Utils.java` to negate sword toggle condition

### DIFF
--- a/src/main/java/keystrokesmod/module/impl/combat/BlockHit.java
+++ b/src/main/java/keystrokesmod/module/impl/combat/BlockHit.java
@@ -113,7 +113,7 @@ public class BlockHit extends Module {
             }
 
             if (mc.thePlayer.getDistanceToEntity(target) <= range.getInput()) {
-                if ((target.hurtResistantTime >= 10 && MODES[(int) eventType.getInput() - 1] == MODES[1]) || (target.hurtResistantTime <= 10 && MODES[(int) eventType.getInput() - 1] == MODES[0])) {
+                if ((target.hurtResistantTime >= 10 && MODES[(int) eventType.getInput()] == MODES[1]) || (target.hurtResistantTime <= 10 && MODES[(int) eventType.getInput()] == MODES[0])) {
 
                     if (onlyPlayers.isToggled()){
                         if (!(target instanceof EntityPlayer)){

--- a/src/main/java/keystrokesmod/utility/Utils.java
+++ b/src/main/java/keystrokesmod/utility/Utils.java
@@ -835,7 +835,7 @@ public static List<String> getSidebarLines() {
             return false;
         }
         Item getItem = item.getItem();
-        return (Settings.weaponSword.isToggled() || getItem instanceof ItemSword) || (Settings.weaponAxe.isToggled() && getItem instanceof ItemAxe) || (Settings.weaponRod.isToggled() && getItem instanceof ItemFishingRod) || (Settings.weaponStick.isToggled() && getItem == Items.stick);
+        return (!Settings.weaponSword.isToggled() || getItem instanceof ItemSword) || (Settings.weaponAxe.isToggled() && getItem instanceof ItemAxe) || (Settings.weaponRod.isToggled() && getItem instanceof ItemFishingRod) || (Settings.weaponStick.isToggled() && getItem == Items.stick);
     }
 
     public static boolean holdingSword() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved logic for recognizing held weapons, ensuring settings for weapon types (sword, axe, rod, stick) are properly respected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->