### PR TITLE
Add `MiddleClick` module to toggle friends or throw pearls in Minecraft

### DIFF
--- a/src/main/java/keystrokesmod/module/ModuleManager.java
+++ b/src/main/java/keystrokesmod/module/ModuleManager.java
@@ -105,6 +105,7 @@ public class ModuleManager {
         this.addModule(new Gui());
         // this.addModule(new NyaProxy());
         this.addModule(new Settings());
+        this.addModule(new MiddleClick());
 
         // combat
         this.addModule(new AimAssist());

--- a/src/main/java/keystrokesmod/module/impl/client/MiddleClick.java
+++ b/src/main/java/keystrokesmod/module/impl/client/MiddleClick.java
@@ -1,0 +1,67 @@
+package keystrokesmod.module.impl.client;
+
+import keystrokesmod.module.Module;
+import keystrokesmod.module.impl.world.AntiBot;
+import keystrokesmod.module.setting.impl.ModeSetting;
+import keystrokesmod.utility.Utils;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.ItemEnderPearl;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent;
+import org.lwjgl.input.Mouse;
+
+public class MiddleClick extends Module {
+    int prevSlot;
+    public static ModeSetting middleClick;
+    private boolean hasClicked;
+    private int pearlEvent;
+
+    public MiddleClick() {
+        super("MiddleClick", category.client, 0);
+        this.registerSetting(middleClick = new ModeSetting("Middle Click", new String[]{"Toggle Friend", "Throw Pearl"}, 0));
+    }
+
+    public void onEnable() {
+        pearlEvent = 4;
+        hasClicked = false;
+    }
+
+    @SubscribeEvent
+    public void onTick(TickEvent.RenderTickEvent e) {
+        if (!Utils.nullCheck())
+            return;
+        if (pearlEvent < 4) {
+            if (pearlEvent == 3) {
+                mc.thePlayer.inventory.currentItem = prevSlot;
+            }
+            pearlEvent++;
+        }
+        if (Mouse.isButtonDown(2) && !hasClicked) {
+            switch ((int) middleClick.getInput()) {
+                case 0: {
+                    EntityLivingBase g = Utils.raytrace(30);
+                    if (g != null && !AntiBot.isBot(g) && !Utils.addFriend(g.getName())) {
+                        Utils.removeFriend(g.getName());
+                    }
+                    break;
+                }
+                case 1: {
+                    for (int slot = 0; slot <= 8; slot++) {
+                        ItemStack itemInSlot = mc.thePlayer.inventory.getStackInSlot(slot);
+                        if (itemInSlot != null && itemInSlot.getItem() instanceof ItemEnderPearl) {
+                            prevSlot = mc.thePlayer.inventory.currentItem;
+                            mc.thePlayer.inventory.currentItem = slot;
+                            mc.playerController.sendUseItem(mc.thePlayer, mc.theWorld, itemInSlot);
+                            pearlEvent = 0;
+                        }
+                    }
+                    break;
+                }
+            }
+            hasClicked = true;
+        } else if (!Mouse.isButtonDown(2) && hasClicked) {
+            hasClicked = false;
+        }
+    }
+}

--- a/src/main/java/keystrokesmod/module/impl/client/Settings.java
+++ b/src/main/java/keystrokesmod/module/impl/client/Settings.java
@@ -12,7 +12,6 @@ public class Settings extends Module {
     public static ButtonSetting weaponAxe;
     public static ButtonSetting weaponRod;
     public static ButtonSetting weaponStick;
-    public static ButtonSetting middleClickFriends;
     public static SliderSetting offset;
     public static SliderSetting timeMultiplier;
     public static ModeSetting toggleSound;

--- a/src/main/java/keystrokesmod/module/impl/client/Settings.java
+++ b/src/main/java/keystrokesmod/module/impl/client/Settings.java
@@ -25,7 +25,6 @@ public class Settings extends Module {
         this.registerSetting(weaponAxe = new ButtonSetting("Set axe as weapon", false));
         this.registerSetting(weaponRod = new ButtonSetting("Set rod as weapon", false));
         this.registerSetting(weaponStick = new ButtonSetting("Set stick as weapon", false));
-        this.registerSetting(middleClickFriends = new ButtonSetting("Middle click friends", false));
         this.registerSetting(new DescriptionSetting("Profiles"));
         this.registerSetting(sendMessage = new ButtonSetting("Send message on enable", true));
         this.registerSetting(new DescriptionSetting("Theme colors"));

--- a/src/main/java/keystrokesmod/utility/clicks/CPSCalculator.java
+++ b/src/main/java/keystrokesmod/utility/clicks/CPSCalculator.java
@@ -42,12 +42,6 @@ public class CPSCalculator {
             } else if (d.button == 1) {
                 aR();
             }
-            else if (d.button == 2 && Settings.middleClickFriends.isToggled()) {
-                EntityLivingBase g = Utils.raytrace(30);
-                if (g != null && !AntiBot.isBot(g) && !Utils.addFriend(g.getName())) {
-                    Utils.removeFriend(g.getName());
-                }
-            }
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `MiddleClick` module enabling middle-click functionality for toggling friends or throwing pearls.

- **Removed Features**
  - Removed the "Middle click friends" setting from the `Settings` class, simplifying the configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->