### PR TITLE
Add team check to proxmity alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
   
 # Raven XD
 <p align="center">
-    <a href="https://github.com/xia-mc/Raven-bS/issues">
-      <img src="https://img.shields.io/github/issues/xia-mc/Raven-bS?style=flat" alt="issues" />
-    </a>
+    <img src="https://img.shields.io/github/issues/xia-mc/Raven-bS?style=flat" alt="issues">
     <img src="https://img.shields.io/badge/license-GPLV3-green" alt="License">
+    <img src="https://tokei.rs/b1/github/xia-mc/Raven-XD?category=code&style=flat" alt="Lines of code">
 </p>
 
 [![Github Release Downloads](https://img.shields.io/github/downloads/xia-mc/Raven-bS/total?label=Github%20Release%20Downloads&style=flat-square)](https://github.com/xia-mc/Raven-bS/releases)

--- a/src/main/java/keystrokesmod/module/impl/other/BedProximityAlert.java
+++ b/src/main/java/keystrokesmod/module/impl/other/BedProximityAlert.java
@@ -20,12 +20,14 @@ public class BedProximityAlert extends Module {
     private final SliderSetting Distance;
     private final ButtonSetting shouldPing;
     private final ButtonSetting tellTheteam;
+    private final ButtonSetting checkTeamMate;
 
     public BedProximityAlert() {
         super("BedProximityAlert", category.other);
         this.registerSetting(Distance = new SliderSetting("Distance", 40, 10, 120, 1));
         this.registerSetting(shouldPing = new ButtonSetting("Should ping", true));
         this.registerSetting(tellTheteam = new ButtonSetting("Tell the team", false));
+        this.registerSetting(checkTeamMate = new ButtonSetting("Check if teammate", false));
         playerAlertStatus = new HashMap<>();
     }
 
@@ -39,10 +41,14 @@ public class BedProximityAlert extends Module {
         BlockPos spawnPos = BedWars.getSpawnPos();
         if (BedWars.whitelistOwnBed.isToggled() && spawnPos != null) {
             for (EntityPlayer otherPlayer : player.worldObj.playerEntities) {
-                if (otherPlayer == player || Utils.isTeamMate(otherPlayer)) {
+                if (otherPlayer == player) {
                     continue;
                 }
-
+                if (!tellTheteam.isToggled()) {
+                    if (Utils.isTeamMate(otherPlayer)){
+                        return;
+                    }
+                }
                 double distance = otherPlayer.getDistance(spawnPos.getX(), spawnPos.getY(), spawnPos.getZ());
                 String playerName = otherPlayer.getDisplayName().getFormattedText();
 

--- a/src/main/java/keystrokesmod/module/impl/other/BedProximityAlert.java
+++ b/src/main/java/keystrokesmod/module/impl/other/BedProximityAlert.java
@@ -27,7 +27,7 @@ public class BedProximityAlert extends Module {
         this.registerSetting(Distance = new SliderSetting("Distance", 40, 10, 120, 1));
         this.registerSetting(shouldPing = new ButtonSetting("Should ping", true));
         this.registerSetting(tellTheteam = new ButtonSetting("Tell the team", false));
-        this.registerSetting(ignoreTeammates = new ButtonSetting("Check if teammate", false));
+        this.registerSetting(ignoreTeammates = new ButtonSetting("Ignore teammates", false));
         playerAlertStatus = new HashMap<>();
     }
 

--- a/src/main/java/keystrokesmod/module/impl/other/BedProximityAlert.java
+++ b/src/main/java/keystrokesmod/module/impl/other/BedProximityAlert.java
@@ -20,14 +20,14 @@ public class BedProximityAlert extends Module {
     private final SliderSetting Distance;
     private final ButtonSetting shouldPing;
     private final ButtonSetting tellTheteam;
-    private final ButtonSetting checkTeamMate;
+    private final ButtonSetting ignoreTeammates;
 
     public BedProximityAlert() {
         super("BedProximityAlert", category.other);
         this.registerSetting(Distance = new SliderSetting("Distance", 40, 10, 120, 1));
         this.registerSetting(shouldPing = new ButtonSetting("Should ping", true));
         this.registerSetting(tellTheteam = new ButtonSetting("Tell the team", false));
-        this.registerSetting(checkTeamMate = new ButtonSetting("Check if teammate", false));
+        this.registerSetting(ignoreTeammates = new ButtonSetting("Check if teammate", false));
         playerAlertStatus = new HashMap<>();
     }
 
@@ -44,7 +44,7 @@ public class BedProximityAlert extends Module {
                 if (otherPlayer == player) {
                     continue;
                 }
-                if (!tellTheteam.isToggled()) {
+                if (!ignoreTeammates.isToggled()) {
                     if (Utils.isTeamMate(otherPlayer)){
                         return;
                     }


### PR DESCRIPTION
<!--NOTE: Please make sure to read the contributing guidelines before submitting your pull request. There is a high chance your PR will be rejected or take a long time to be merged if you don't follow the guidelines. Thank you for your understanding - and thanks for taking the time to contribute!!-->

## Description
> Add team check to bed proxmity alert module

## Testing
> It work on hypixel 1.8.9

## References
> List any related issues, forum posts, videos and such here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new setting to customize alerts based on teammate proximity.
	- Added a configuration option to allow users to specify whether to check for teammates before sending notifications.

- **Improvements**
	- Enhanced control over gameplay notifications by refining the conditions under which alerts are sent, allowing for more granular user preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->