### PR TITLE
Add ignore teammates to bedwars proxmity alert [REPOST]

### DIFF
--- a/src/main/java/keystrokesmod/module/impl/other/BedProximityAlert.java
+++ b/src/main/java/keystrokesmod/module/impl/other/BedProximityAlert.java
@@ -20,12 +20,14 @@ public class BedProximityAlert extends Module {
     private final SliderSetting Distance;
     private final ButtonSetting shouldPing;
     private final ButtonSetting tellTheteam;
+    private final ButtonSetting ignoreTeammates;
 
     public BedProximityAlert() {
         super("BedProximityAlert", category.other);
         this.registerSetting(Distance = new SliderSetting("Distance", 40, 10, 120, 1));
         this.registerSetting(shouldPing = new ButtonSetting("Should ping", true));
         this.registerSetting(tellTheteam = new ButtonSetting("Tell the team", false));
+        this.registerSetting(ignoreTeammates = new ButtonSetting("Ignore teammates", false));
         playerAlertStatus = new HashMap<>();
     }
 
@@ -39,10 +41,14 @@ public class BedProximityAlert extends Module {
         BlockPos spawnPos = BedWars.getSpawnPos();
         if (BedWars.whitelistOwnBed.isToggled() && spawnPos != null) {
             for (EntityPlayer otherPlayer : player.worldObj.playerEntities) {
-                if (otherPlayer == player || Utils.isTeamMate(otherPlayer)) {
+                if (otherPlayer == player) {
                     continue;
                 }
-
+                if (ignoreTeammates.isToggled()) {
+                    if (Utils.isTeamMate(otherPlayer)){
+                        return;
+                    }
+                }    
                 double distance = otherPlayer.getDistance(spawnPos.getX(), spawnPos.getY(), spawnPos.getZ());
                 String playerName = otherPlayer.getDisplayName().getFormattedText();
 


### PR DESCRIPTION
<!--NOTE: Please make sure to read the contributing guidelines before submitting your pull request. There is a high chance your PR will be rejected or take a long time to be merged if you don't follow the guidelines. Thank you for your understanding - and thanks for taking the time to contribute!!-->

## Description
> Add team check to bed proxmity alert module

## Testing
> Work

## References
> List any related issues, forum posts, videos and such here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new setting to the proximity alert system that allows users to ignore alerts from teammates, enhancing customization based on gameplay strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->