### PR TITLE
Fixed rod slot being incorrect default value (1, 2, 3, 4, 5, 6, 8) no…

### DIFF
--- a/src/main/java/keystrokesmod/module/impl/player/InvManager.java
+++ b/src/main/java/keystrokesmod/module/impl/player/InvManager.java
@@ -44,7 +44,7 @@ public class InvManager extends Module {
     private final SliderSetting bowSlot = new SliderSetting("Bow slot", 4, 0, 9, 1, sort::isToggled);
     private final SliderSetting foodSlot = new SliderSetting("Food slot", 5, 0, 9, 1, sort::isToggled);
     private final SliderSetting throwableSlot = new SliderSetting("Throwable slot", 6, 0, 9, 1, sort::isToggled);
-    private final SliderSetting rodSlot = new SliderSetting("Rod slot", 8, 0, 9, 1, sort::isToggled);
+    private final SliderSetting rodSlot = new SliderSetting("Rod slot", 7, 0, 9, 1, sort::isToggled);
     private final ButtonSetting shuffle = new ButtonSetting("Shuffle", false, () -> armor.isToggled() || clean.isToggled() || sort.isToggled());
 
     private State state = State.NONE;


### PR DESCRIPTION
…w 1, 2, 3, 4, 5, 6, 7

<!--NOTE: Please make sure to read the contributing guidelines before submitting your pull request. There is a high chance your PR will be rejected or take a long time to be merged if you don't follow the guidelines. Thank you for your understanding - and thanks for taking the time to contribute!!-->

## Description
> title

## Testing
> works perfectly

## References
> List any related issues, forum posts, videos and such here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Adjusted the inventory management system to change the default rod slot from 8 to 7, enhancing user configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->