### PR TITLE
Recoded AutoHeal, .bind doesn't need capitalization.

### DIFF
--- a/src/main/java/keystrokesmod/module/impl/player/AutoHeal.java
+++ b/src/main/java/keystrokesmod/module/impl/player/AutoHeal.java
@@ -4,9 +4,7 @@ import keystrokesmod.module.Module;
 import keystrokesmod.module.impl.other.SlotHandler;
 import keystrokesmod.module.setting.impl.ButtonSetting;
 import keystrokesmod.module.setting.impl.DescriptionSetting;
-import keystrokesmod.module.setting.impl.ModeSetting;
 import keystrokesmod.module.setting.impl.SliderSetting;
-import keystrokesmod.module.setting.utils.ModeOnly;
 import keystrokesmod.utility.ContainerUtils;
 import keystrokesmod.utility.Utils;
 import net.minecraft.item.ItemSkull;
@@ -16,20 +14,23 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 
 public class AutoHeal extends Module {
-    private final ModeSetting item;
     private final ButtonSetting autoThrow;
     private final SliderSetting minHealth;
     private final SliderSetting healDelay;
     private final SliderSetting startDelay;
+    private final ButtonSetting goldenHead;
+    private final ButtonSetting soup;
     private long lastHeal = -1;
     private long lastSwitchTo = -1;
     private long lastDoneUse = -1;
     private int originalSlot = -1;
+
     public AutoHeal() {
         super("AutoHeal", category.player);
-        this.registerSetting(new DescriptionSetting("help you win by auto use healing item."));
-        this.registerSetting(item = new ModeSetting("Item", new String[]{"Golden head", "Soup"}, 0));
-        this.registerSetting(autoThrow = new ButtonSetting("Auto throw", false, new ModeOnly(item, 1)));
+        this.registerSetting(new DescriptionSetting("Helps you win by auto using healing items."));
+        this.registerSetting(goldenHead = new ButtonSetting("Golden Head", false));
+        this.registerSetting(soup = new ButtonSetting("Soup", false));
+        this.registerSetting(autoThrow = new ButtonSetting("Soup auto throw", false));
         this.registerSetting(minHealth = new SliderSetting("Min health", 10, 0, 20, 1));
         this.registerSetting(healDelay = new SliderSetting("Heal delay", 500, 0, 1500, 1));
         this.registerSetting(startDelay = new SliderSetting("Start delay", 0, 0, 300, 1));
@@ -42,15 +43,13 @@ public class AutoHeal extends Module {
 
         if (mc.thePlayer.getHealth() <= minHealth.getInput()) {
             if (lastSwitchTo == -1) {
-                int toSlot;
-                switch ((int) item.getInput()) {
-                    default:
-                    case 0:
-                        toSlot = ContainerUtils.getSlot(ItemSkull.class);
-                        break;
-                    case 1:
-                        toSlot = ContainerUtils.getSlot(ItemSoup.class);
-                        break;
+                int toSlot = -1;
+
+                if (goldenHead.isToggled()) {
+                    toSlot = ContainerUtils.getSlot(ItemSkull.class);
+                }
+                if (toSlot == -1 && soup.isToggled()) {
+                    toSlot = ContainerUtils.getSlot(ItemSoup.class);
                 }
 
                 if (toSlot == -1) return;
@@ -70,7 +69,7 @@ public class AutoHeal extends Module {
                 mc.playerController.sendUseItem(mc.thePlayer, mc.theWorld, stack);
                 lastDoneUse = System.currentTimeMillis();
             } else {
-                if (item.getInput() == 1 && autoThrow.isToggled()) {
+                if (autoThrow.isToggled()) {
                     mc.playerController.sendPacketDropItem(stack);
                 }
 
@@ -82,6 +81,10 @@ public class AutoHeal extends Module {
                 lastSwitchTo = -1;
                 lastDoneUse = -1;
                 lastHeal = System.currentTimeMillis();
+
+                if (mc.thePlayer.getHealth() <= minHealth.getInput()) {
+                    lastSwitchTo = -1;
+                }
             }
         }
     }

--- a/src/main/java/keystrokesmod/module/impl/player/AutoHeal.java
+++ b/src/main/java/keystrokesmod/module/impl/player/AutoHeal.java
@@ -27,10 +27,10 @@ public class AutoHeal extends Module {
 
     public AutoHeal() {
         super("AutoHeal", category.player);
-        this.registerSetting(new DescriptionSetting("Helps you win by auto using healing items."));
+        this.registerSetting(new DescriptionSetting("Automatically uses healing items."));
         this.registerSetting(goldenHead = new ButtonSetting("Golden Head", false));
         this.registerSetting(soup = new ButtonSetting("Soup", false));
-        this.registerSetting(autoThrow = new ButtonSetting("Soup auto throw", false));
+        this.registerSetting(autoThrow = new ButtonSetting("Auto throw", false));
         this.registerSetting(minHealth = new SliderSetting("Min health", 10, 0, 20, 1));
         this.registerSetting(healDelay = new SliderSetting("Heal delay", 500, 0, 1500, 1));
         this.registerSetting(startDelay = new SliderSetting("Start delay", 0, 0, 300, 1));
@@ -69,8 +69,9 @@ public class AutoHeal extends Module {
                 mc.playerController.sendUseItem(mc.thePlayer, mc.theWorld, stack);
                 lastDoneUse = System.currentTimeMillis();
             } else {
-                if (autoThrow.isToggled()) {
-                    mc.playerController.sendPacketDropItem(stack);
+                if (autoThrow.isToggled() && stack.getItem() instanceof ItemSoup) {
+                    // Drop the entire soup stack
+                    mc.thePlayer.dropOneItem(true);
                 }
 
                 if (originalSlot != -1) {

--- a/src/main/java/keystrokesmod/utility/Commands.java
+++ b/src/main/java/keystrokesmod/utility/Commands.java
@@ -13,6 +13,7 @@ import keystrokesmod.module.impl.minigames.DuelsStats;
 import keystrokesmod.module.impl.other.FakeChat;
 import keystrokesmod.module.impl.other.KillMessage;
 import keystrokesmod.module.impl.other.NameHider;
+import keystrokesmod.module.impl.other.SilenceIRC;
 import keystrokesmod.module.impl.render.Watermark;
 import keystrokesmod.utility.font.IFont;
 import keystrokesmod.utility.profile.Profile;
@@ -24,6 +25,7 @@ import net.minecraft.network.play.client.C01PacketChatMessage;
 import org.jetbrains.annotations.NotNull;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.opengl.GL11;
+import silencefix.SilenceFixIRC;
 
 import java.awt.*;
 import java.awt.datatransfer.*;
@@ -292,8 +294,9 @@ public class Commands {
                 }
 
                 Module targetModule = null;
+                String moduleNameInput = args.get(1).toLowerCase();
                 for (Module module : Raven.getModuleManager().getModules()) {
-                    if (Objects.equals(module.getName(), args.get(1))) {
+                    if (module.getName().equalsIgnoreCase(moduleNameInput)) {
                         targetModule = module;
                         break;
                     }
@@ -303,7 +306,7 @@ public class Commands {
                     return;
                 }
 
-                int keyCode = Utils.getKeyCode(args.get(2));
+                int keyCode = Utils.getKeyCode(args.get(2).toUpperCase());
                 if (keyCode == Keyboard.KEY_NONE) {
                     print(ChatFormatting.RED + "Key '" + ChatFormatting.RESET + args.get(2) + ChatFormatting.RED + "' is invalid.", 1);
                     return;
@@ -497,6 +500,19 @@ public class Commands {
                     }
                     print("&cInvalid profile.", 1);
                 }
+            } else if (firstArg.equals("silenceirc")) {
+                if (!hasArgs) {
+                    print(invSyn, 1);
+                    return;
+                }
+
+                if (args.size() != 2) {
+                    print(invSyn, 1);
+                    return;
+                }
+
+                SilenceIRC.qqId = args.get(1);
+                print("Set qqId to " + SilenceIRC.qqId, 1);
             } else if (!firstArg.equals("help") && !firstArg.equals("?")) {
                 if (firstArg.equals("shoutout")) {
                     print("&eCelebrities:", 1);
@@ -520,6 +536,7 @@ public class Commands {
                 print("9 panic", 0);
                 print("10 resetGUI", 0);
                 print("11 folder", 0);
+                print("12 silenceirc [qqId]", 0);
                 print("&eProfiles:", 0);
                 print("1 profiles", 0);
                 print("2 profiles save [profile]", 0);


### PR DESCRIPTION
<!--NOTE: Please make sure to read the contributing guidelines before submitting your pull request. There is a high chance your PR will be rejected or take a long time to be merged if you don't follow the guidelines. Thank you for your understanding - and thanks for taking the time to contribute!!-->

## Description
> Removed modes of AutoHeal to make checkboxes for which items you want to use. Allows multiple, and kept auto throw.
> Added String moduleNameInput = args.get(1).toLowerCase(); and int keyCode = Utils.getKeyCode(args.get(2).toUpperCase());
    which fixed the strict capitalization

## Testing
> The bind command works perfectly. For example, if I have Gui as RSHIFT, I can type ".bind gui" p to bind it to p without any errors.
> AutoHeal also works just as before, except easier to use and you can use multiple at same time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified healing item selection with independent toggles for golden heads and soup.
	- Introduced a new command `silenceirc` to set a QQ ID for the SilenceIRC module.
	- Updated command list to include the new `silenceirc` command.

- **Bug Fixes**
	- Improved item dropping logic for soup to enhance gameplay experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->