### PR TITLE
Patch for SmoothBackRotate in RotationHandler

### DIFF
--- a/src/main/java/keystrokesmod/module/impl/other/RotationHandler.java
+++ b/src/main/java/keystrokesmod/module/impl/other/RotationHandler.java
@@ -128,14 +128,18 @@ public final class RotationHandler extends Module {
         if (isSet && mc.currentScreen == null) {
             float viewYaw = RotationUtils.normalize(mc.thePlayer.rotationYaw);
             float viewPitch = RotationUtils.normalize(mc.thePlayer.rotationPitch);
+
+            float serverYaw = RotationUtils.normalize(getRotationYaw());
+            float serverPitch = RotationUtils.normalize(getRotationPitch());
+
             switch ((int) smoothBack.getInput()) {
                 case 0:
                     rotationYaw = null;
                     rotationPitch = null;
                     break;
                 case 1:
-                    setRotationYaw(AimSimulator.rotMove(viewYaw, getRotationYaw(), (float) aimSpeed.getInput()));
-                    setRotationPitch(AimSimulator.rotMove(viewPitch, getRotationPitch(), (float) aimSpeed.getInput()));
+                    setRotationYaw(AimSimulator.rotMove(viewYaw, serverYaw, (float) aimSpeed.getInput()));
+                    setRotationPitch(AimSimulator.rotMove(viewPitch, serverPitch, (float) aimSpeed.getInput()));
                     break;
             }
         }


### PR DESCRIPTION
Would be cool if the actual source of the problem would be fixed(getRotationYaw generating values over 360) but this works to fix the problem so that we can actually use SmoothBack for now

## Description
> Normalizing CurrentYaw fixes SmoothBack Default sometimes starting to randomly jitter

## Testing
> Sometimes getRotationYaw() randomly goes over 360, I've looked at the code and I don't understand how it happens. But normalizing the value fixes it. https://github.com/Kefpull/Kef_Raven-XD/releases/tag/v2.13.3 
![Raven XD 2 13 12_9_2024 1_00_27 PM](https://github.com/user-attachments/assets/f7a53690-0464-4bc0-a022-9872345c9b9d)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved accuracy of player rotation adjustments during movement.
	- Enhanced responsiveness of player movement with refined calculations for movement angles.

- **Bug Fixes**
	- Implemented checks to reset rotation values when they match the player's current state, preventing outdated values from being used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->